### PR TITLE
Fix redirect route in ArticleController

### DIFF
--- a/app/Http/Controllers/ArticleController.php
+++ b/app/Http/Controllers/ArticleController.php
@@ -77,7 +77,7 @@ class ArticleController extends Controller
         if($article->restore()) {
             return redirect()->route('articles')->with('success', 'Статтю успішно відновлено!');
         }  
-        return redirect()->route('articles.softDelete')->with('danger', 'Помилка відновлення статті!'); 
+        return redirect()->route('articles.softdeleted')->with('danger', 'Помилка відновлення статті!');
     }
 
     /**


### PR DESCRIPTION
## Summary
- fix incorrect route name after restoring articles

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a2a9701c8332aefd9d571a24d8dc