### PR TITLE
Improve header buttons and forms

### DIFF
--- a/public/css/futuretech.css
+++ b/public/css/futuretech.css
@@ -346,3 +346,37 @@ nav.header__nav {
   display: none;
 }
 
+/* Form Styling */
+.card {
+  background-color: var(--color-bg-alt);
+  border: 1px solid var(--color-divider);
+  border-radius: 0.5rem;
+  color: var(--color-text);
+}
+.card-header {
+  background-color: var(--color-bg-alt);
+  border-bottom: 1px solid var(--color-divider);
+  font-family: var(--font-secondary);
+  font-weight: 700;
+}
+.form-control {
+  background-color: var(--color-bg);
+  border: 1px solid var(--color-divider);
+  color: var(--color-text);
+}
+.form-control:focus {
+  background-color: var(--color-bg);
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 0.2rem rgba(255, 214, 0, 0.25);
+}
+.btn-primary {
+  background-color: var(--color-accent);
+  border-color: var(--color-accent);
+  color: var(--color-bg-alt);
+}
+.btn-primary:hover {
+  background-color: #FFB300;
+  border-color: #FFB300;
+  color: var(--color-bg-alt);
+}
+

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -57,9 +57,9 @@
                     </ul>
                     <ul class="nav__list nav__auth">
                         @guest
-                            <li class="nav__item"><a class="nav__link" href="{{ route('login') }}">{{ __('Вхід') }}</a></li>
+                            <li class="nav__item"><a class="btn btn--accent" href="{{ route('login') }}">{{ __('Вхід') }}</a></li>
                             @if (Route::has('register'))
-                                <li class="nav__item"><a class="nav__link" href="{{ route('register') }}">{{ __('Реєстрація') }}</a></li>
+                                <li class="nav__item"><a class="btn btn--accent" href="{{ route('register') }}">{{ __('Реєстрація') }}</a></li>
                             @endif
                         @else
                             <li class="nav__item dropdown">


### PR DESCRIPTION
## Summary
- style header login/register as accent buttons
- add dark theme styles for cards and form controls

## Testing
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840babafc348332acfd000b727f4ec0