### PR TITLE
Fix Intervention Image driver configuration

### DIFF
--- a/config/image.php
+++ b/config/image.php
@@ -15,6 +15,6 @@ return [
     |
     */
 
-    'driver' => 'gd'
+    'driver' => Intervention\Image\Drivers\Gd\Driver::class
 
 ];


### PR DESCRIPTION
## Summary
- update the `config/image.php` driver to use the GD driver class

## Testing
- `php artisan --version` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840bce287b483329342636faa596ed9