### PR TITLE
Update layout and account page

### DIFF
--- a/public/css/futuretech.css
+++ b/public/css/futuretech.css
@@ -19,6 +19,17 @@ body {
   font-family: var(--font-secondary);
   line-height: 1.6;
 }
+html, body {
+  height: 100%;
+}
+#app {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+main {
+  flex: 1 0 auto;
+}
 .site-container {
   max-width: 1280px;
   margin: 0 auto;
@@ -378,5 +389,11 @@ nav.header__nav {
   background-color: #FFB300;
   border-color: #FFB300;
   color: var(--color-bg-alt);
+}
+
+.list-group-item {
+  background-color: var(--color-bg-alt);
+  border-color: var(--color-divider);
+  color: var(--color-text);
 }
 

--- a/resources/sass/blog.scss
+++ b/resources/sass/blog.scss
@@ -1,3 +1,17 @@
+html, body {
+    height: 100%;
+}
+
+#app {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+main {
+    flex: 1 0 auto;
+}
+
 body {
     background-color: #f4f5f7;
 }
@@ -8,4 +22,10 @@ body {
 
 footer {
     font-size: 0.875rem;
+}
+
+.list-group-item {
+    background-color: #1A1A1A;
+    border-color: #2A2A2A;
+    color: #FFFFFF;
 }

--- a/resources/views/auth/profile.blade.php
+++ b/resources/views/auth/profile.blade.php
@@ -8,27 +8,25 @@
                  <div class="card-header">{{ __('Деталі аккаунту') }}</div>
                 
                 <div class="card-body">
-                   
-                    <div class="card">
-                        <ul class="list-group list-group-flush">
-                            <li class="list-group-item ">Аватар: <img src="{{$auth_user->avatar}}" style="height:100px"/></li>
-                            <li class="list-group-item">Нікнейм: {{$auth_user->nickname}}</li>
-                            <li class="list-group-item">Прізвище: {{$auth_user->surname}}</li>
-                            @if($auth_user->show_phone)
-                                <li class="list-group-item">Телефон: {{$auth_user->phone}}</li>
-                            @endif
-                            <li class="list-group-item">Стать: 
-                                @if ($auth_user->sex === 'Male')
-                                    Чоловік
-                                @elseif ($auth_user->sex === 'Female')
-                                    Жінка
-                                @else
-                                    Undefined
-                                @endif
-                            </li>
-                            {{--  <li class="list-group-item">Показати телефон: {{$auth_user->show_phone}}</li>  --}}
-                          </ul>
+                    <div class="text-center mb-4">
+                        <img src="{{$auth_user->avatar}}" alt="Avatar" class="rounded-circle" style="width:120px;height:120px;">
                     </div>
+                    <ul class="list-group list-group-flush">
+                        <li class="list-group-item">Нікнейм: {{$auth_user->nickname}}</li>
+                        <li class="list-group-item">Прізвище: {{$auth_user->surname}}</li>
+                        @if($auth_user->show_phone)
+                            <li class="list-group-item">Телефон: {{$auth_user->phone}}</li>
+                        @endif
+                        <li class="list-group-item">Стать:
+                            @if ($auth_user->sex === 'Male')
+                                Чоловік
+                            @elseif ($auth_user->sex === 'Female')
+                                Жінка
+                            @else
+                                Undefined
+                            @endif
+                        </li>
+                    </ul>
                     @if(session()->get('success'))
                         <div class="alert alert-success mt-2">
                             {{ session()->get('success') }}

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -24,19 +24,6 @@
 </head>
 <body>
     <div id="app">
-        <!-- Top Bar -->
-        <div class="top-bar">
-            <div class="site-container top-bar__inner">
-                <p class="top-bar__text">
-                    Subscribe to our Newsletter For New & latest Blogs and Resources
-                    <a href="/newsletter" class="top-bar__arrow-link" aria-label="Go to newsletter signup">
-                        <svg width="16" height="16" fill="var(--color-accent)" xmlns="http://www.w3.org/2000/svg">
-                            <path d="M4 8h8M8 4l4 4-4 4" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-                        </svg>
-                    </a>
-                </p>
-            </div>
-        </div>
         <header class="site-header">
             <div class="site-container header__inner">
                 <a href="/" class="header__logo">


### PR DESCRIPTION
## Summary
- tidy header by removing the newsletter bar
- tweak account details page layout
- keep footer fixed to the bottom
- add dark theme styles for list items

## Testing
- `npm --version`
- `npm test --silent`
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840c0d3b45c8332b5a97ed6432b7a32