### PR TITLE
Add light theme with switcher

### DIFF
--- a/public/css/futuretech.css
+++ b/public/css/futuretech.css
@@ -3,13 +3,21 @@
   --color-bg-alt: #1A1A1A;
   --color-text: #FFFFFF;
   --color-text-muted: rgba(255, 255, 255, 0.7);
-  --color-accent: #FFD600;
+  --color-accent: #0091FF;
   --color-divider: #2A2A2A;
   --font-primary: 'Inter', sans-serif;
   --font-secondary: 'Roboto', sans-serif;
   --spacing-unit: 1rem;
 }
 html {
+[data-theme="light"] {
+  --color-bg: #FFFFFF;
+  --color-bg-alt: #F5F5F5;
+  --color-text: #000000;
+  --color-text-muted: rgba(0,0,0,0.7);
+  --color-divider: #E0E0E0;
+  --color-accent: #0091FF;
+}
   font-size: 16px;
 }
 body {
@@ -356,6 +364,14 @@ nav.header__nav {
 }
 .header__toggle {
   display: none;
+}
+.theme-toggle {
+  background: none;
+  border: none;
+  color: var(--color-text);
+  cursor: pointer;
+  font-size: 1.2rem;
+  margin-left: 1rem;
 }
 
 /* Form Styling */
@@ -1062,7 +1078,7 @@ nav.header__nav {
 
 .similar-news-header a {
   font-size: 14px;
-  color: #FFCC00;
+  color: var(--color-accent);
   text-decoration: none;
 }
 
@@ -1113,7 +1129,7 @@ nav.header__nav {
 .similar-card__link {
   margin: auto 16px 16px 16px;
   font-size: 14px;
-  color: #FFCC00;
+  color: var(--color-accent);
   text-decoration: none;
 }
 
@@ -1224,7 +1240,7 @@ nav.header__nav {
 .ft-card__link {
   align-self: flex-end;
   display: inline-flex;
-  background-color: #FFCC00;
+  background-color: var(--color-accent);
   width: 32px;
   height: 32px;
   border-radius: 50%;

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -6,6 +6,7 @@
 
 require('./bootstrap');
 
+require('./theme');
 window.Vue = require('vue');
 
 /**

--- a/resources/js/theme.js
+++ b/resources/js/theme.js
@@ -1,0 +1,18 @@
+export default function initThemeToggle() {
+    const toggle = document.getElementById('theme-toggle');
+    const saved = localStorage.getItem('theme');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const theme = saved || (prefersDark ? 'dark' : 'light');
+    document.documentElement.setAttribute('data-theme', theme);
+
+    if (toggle) {
+        toggle.addEventListener('click', () => {
+            const current = document.documentElement.getAttribute('data-theme');
+            const next = current === 'dark' ? 'light' : 'dark';
+            document.documentElement.setAttribute('data-theme', next);
+            localStorage.setItem('theme', next);
+        });
+    }
+}
+
+document.addEventListener('DOMContentLoaded', initThemeToggle);

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -2,10 +2,52 @@
 
 @section('content')
 
+<section class="hero">
+    <div class="site-container hero__inner">
+        <div class="hero__content">
+            <h1 class="hero__title">Explore the Frontiers of Artificial Intelligence</h1>
+            <p class="hero__subtitle">
+                Welcome to the epicenter of AI innovation. FutureTech AI News is your passport to a world where machines think, learn, and reshape the future. Join us on this visionary expedition into the heart of AI.
+            </p>
+            <div class="hero__stats">
+                <div class="stat-card">
+                    <p class="stat-card__number">300<span class="stat-card__plus">+</span></p>
+                    <p class="stat-card__label">Resources available</p>
+                </div>
+                <div class="stat-card">
+                    <p class="stat-card__number">12k<span class="stat-card__plus">+</span></p>
+                    <p class="stat-card__label">Total Downloads</p>
+                </div>
+                <div class="stat-card">
+                    <p class="stat-card__number">10k<span class="stat-card__plus">+</span></p>
+                    <p class="stat-card__label">Active Users</p>
+                </div>
+            </div>
+        </div>
+        <div class="hero__graphic">
+            <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100'%3E%3Crect width='100%25' height='100%25' fill='%23ccc'/%3E%3C/svg%3E" alt="Futuristic AI network graphic" class="hero__image" />
+            <div class="resources-widget">
+                <div class="resources-widget__avatars">
+                    <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32'%3E%3Crect width='100%25' height='100%25' fill='%23ccc'/%3E%3C/svg%3E" alt="Expert 1" class="avatar">
+                    <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32'%3E%3Crect width='100%25' height='100%25' fill='%23ccc'/%3E%3C/svg%3E" alt="Expert 2" class="avatar">
+                    <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32'%3E%3Crect width='100%25' height='100%25' fill='%23ccc'/%3E%3C/svg%3E" alt="Expert 3" class="avatar">
+                </div>
+                <p class="resources-widget__text">Explore 1000+ resources</p>
+                <p class="resources-widget__subtext">Over 1,000 articles on emerging tech trends and breakthroughs.</p>
+                <a href="/resources" class="resources-widget__btn">
+                    Explore Resources
+                    <svg width="16" height="16" fill="var(--color-accent)" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M4 8h8M8 4l4 4-4 4" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+                    </svg>
+                </a>
+            </div>
+        </div>
+    </div>
+</section>
 <section class="ft-hero">
     <div class="ft-hero__inner container">
         <div class="ft-hero__logo">
-            <svg class="ft-hero__logo-image" width="64" height="64" fill="#FFCC00" xmlns="http://www.w3.org/2000/svg">
+            <svg class="ft-hero__logo-image" width="64" height="64" fill="var(--color-accent)" xmlns="http://www.w3.org/2000/svg">
                 <path d="M16 0C7.163 0 0 7.163 0 16s7.163 16 16 16 16-7.163 16-16S24.837 0 16 0zm0 30C8.28 30 2 23.72 2 16S8.28 2 16 2s14 6.28 14 14-6.28 14-14 14z"/>
                 <path d="M11 11h10v10H11z"/>
             </svg>
@@ -51,46 +93,10 @@
     </div>
 </section>
 
-<section class="hero">
-    <div class="site-container hero__inner">
-        <div class="hero__content">
-            <h1 class="hero__title">Explore the Frontiers of Artificial Intelligence</h1>
-            <p class="hero__subtitle">
-                Welcome to the epicenter of AI innovation. FutureTech AI News is your passport to a world where machines think, learn, and reshape the future. Join us on this visionary expedition into the heart of AI.
-            </p>
-            <div class="hero__stats">
-                <div class="stat-card">
-                    <p class="stat-card__number">300<span class="stat-card__plus">+</span></p>
-                    <p class="stat-card__label">Resources available</p>
-                </div>
-                <div class="stat-card">
-                    <p class="stat-card__number">12k<span class="stat-card__plus">+</span></p>
-                    <p class="stat-card__label">Total Downloads</p>
-                </div>
-                <div class="stat-card">
-                    <p class="stat-card__number">10k<span class="stat-card__plus">+</span></p>
-                    <p class="stat-card__label">Active Users</p>
-                </div>
-            </div>
-        </div>
-        <div class="hero__graphic">
-            <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100'%3E%3Crect width='100%25' height='100%25' fill='%23ccc'/%3E%3C/svg%3E" alt="Futuristic AI network graphic" class="hero__image" />
-            <div class="resources-widget">
-                <div class="resources-widget__avatars">
-                    <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32'%3E%3Crect width='100%25' height='100%25' fill='%23ccc'/%3E%3C/svg%3E" alt="Expert 1" class="avatar">
-                    <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32'%3E%3Crect width='100%25' height='100%25' fill='%23ccc'/%3E%3C/svg%3E" alt="Expert 2" class="avatar">
-                    <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32'%3E%3Crect width='100%25' height='100%25' fill='%23ccc'/%3E%3C/svg%3E" alt="Expert 3" class="avatar">
-                </div>
-                <p class="resources-widget__text">Explore 1000+ resources</p>
-                <p class="resources-widget__subtext">Over 1,000 articles on emerging tech trends and breakthroughs.</p>
-                <a href="/resources" class="resources-widget__btn">
-                    Explore Resources
-                    <svg width="16" height="16" fill="var(--color-accent)" xmlns="http://www.w3.org/2000/svg">
-                        <path d="M4 8h8M8 4l4 4-4 4" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-                    </svg>
-                </a>
-            </div>
-        </div>
+<section class="features-intro">
+    <div class="site-container features-intro__inner">
+        <p class="features-intro__pretitle">Unlock the Power of</p>
+        <h2 class="features-intro__title">FutureTech Features</h2>
     </div>
 </section>
 <section class="features-strip">
@@ -125,12 +131,6 @@
             <h3 class="feature-card__title">Global Readership</h3>
             <p class="feature-card__subtitle">2 million monthly readers</p>
         </div>
-    </div>
-</section>
-<section class="features-intro">
-    <div class="site-container features-intro__inner">
-        <p class="features-intro__pretitle">Unlock the Power of</p>
-        <h2 class="features-intro__title">FutureTech Features</h2>
     </div>
 </section>
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -50,6 +50,7 @@
                     <span class="sr-only">FutureTech</span>
                 </a>
                 <button class="header__toggle" id="nav-toggle">☰</button>
+                <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">🌓</button>
                 <nav class="header__nav">
                     <ul class="nav__list nav__primary">
                         <li class="nav__item"><a href="{{ url('/') }}" class="nav__link {{ request()->is('/') ? 'nav__link--active' : '' }}">Головна</a></li>
@@ -95,7 +96,7 @@
         <footer class="site-footer">
             <div class="site-footer__inner container">
                 <div class="footer-col footer-col--branding">
-                    <svg class="footer-logo" width="48" height="48" fill="#FFCC00" xmlns="http://www.w3.org/2000/svg">
+                    <svg class="footer-logo" width="48" height="48" fill="var(--color-accent)" xmlns="http://www.w3.org/2000/svg">
                         <path d="M16 0C7.163 0 0 7.163 0 16s7.163 16 16 16 16-7.163 16-16S24.837 0 16 0zm0 30C8.28 30 2 23.72 2 16S8.28 2 16 2s14 6.28 14 14-6.28 14-14 14z"/>
                         <path d="M11 11h10v10H11z"/>
                     </svg>


### PR DESCRIPTION
## Summary
- reorder main page sections for a more natural flow
- add a theme toggle button and new JS to handle switching
- support light theme colors and changed primary accent to blue

## Testing
- `NODE_OPTIONS=--openssl-legacy-provider npm run dev`
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840d6aec0208332a531b41b3a3bdcbb