### PR TITLE
UI cleanup and layout tweaks

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -10938,7 +10938,7 @@ footer {
   display: flex;
   justify-content: center;
   align-items: center;
-  padding-top: 80px;
+  padding-top: 0;
 }
 
 .login-page .card {
@@ -10946,13 +10946,7 @@ footer {
   max-width: 400px;
 }
 
-.login-page .card-header {
-  margin-bottom: 24px;
-  border: none;
-  background: transparent;
-  text-align: center;
-  font-size: 1.5rem;
-}
+
 
 .login-page .form-group {
   margin-bottom: 12px;

--- a/public/css/futuretech.css
+++ b/public/css/futuretech.css
@@ -1480,3 +1480,38 @@ nav.header__nav {
 }
 
 @media (max-width: 480px) {.btn,.button{font-size:1.1rem;padding-left:1rem;padding-right:1rem;} }
+
+/* Global UI tweaks */
+h1, h2, h3 {
+  margin-top: 24px;
+  margin-bottom: 16px;
+}
+
+section {
+  margin-top: 24px;
+  margin-bottom: 16px;
+}
+
+.form-group {
+  margin-bottom: 12px;
+}
+
+.btn,
+.action-button {
+  padding: 10px 20px;
+  border-radius: 6px;
+  margin-top: 16px;
+}
+
+.btn--accent {
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  transition: background-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.form-centered {
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+}

--- a/resources/views/auth/edit.blade.php
+++ b/resources/views/auth/edit.blade.php
@@ -2,11 +2,10 @@
 
 @section('content')
 @include('partials.page-banner', ['title' => __('Редагувати інформацію')])
-<div class="site-container">
+<div class="site-container form-centered">
     <div class="row justify-content-center">
         <div class="col-md-8">
             <div class="card">
-                <div class="card-header">{{ __('Редагувати інформацію') }}</div>
 
                 <div class="card-body">
                     <form method="POST" action="{{ route('users.update', $user->id) }}" enctype="multipart/form-data">

--- a/resources/views/auth/editPassword.blade.php
+++ b/resources/views/auth/editPassword.blade.php
@@ -2,11 +2,10 @@
 
 @section('content')
 @include('partials.page-banner', ['title' => __('Змінити пароль')])
-<div class="site-container">
+<div class="site-container form-centered">
     <div class="row justify-content-center">
         <div class="col-md-8">
             <div class="card">
-                <div class="card-header">{{ __('Змінити пароль') }}</div>
 
                 <div class="card-body">
                     @if(session()->get('success'))

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,11 +1,10 @@
 @extends('layouts.app')
 
 @section('content')
-<div class="site-container login-page">
+<div class="site-container login-page form-centered">
     <div class="row justify-content-center">
         <div class="col-md-8 col-lg-5">
             <div class="card">
-                <h1 class="card-header">{{ __('Вхід') }}</h1>
 
                 <div class="card-body">
                     <form method="POST" action="{{ route('login') }}">

--- a/resources/views/auth/passwords/confirm.blade.php
+++ b/resources/views/auth/passwords/confirm.blade.php
@@ -2,11 +2,10 @@
 
 @section('content')
 @include('partials.page-banner', ['title' => __('Підтвердіть пароль')])
-<div class="site-container">
+<div class="site-container form-centered">
     <div class="row justify-content-center">
         <div class="col-md-8">
             <div class="card">
-                <div class="card-header">{{ __('Підтвердіть пароль') }}</div>
 
                 <div class="card-body">
                     {{ __('Будь ласка, підтвердіть пароль перед продовженням.') }}

--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -2,11 +2,10 @@
 
 @section('content')
 @include('partials.page-banner', ['title' => __('Скидання пароля')])
-<div class="site-container">
+<div class="site-container form-centered">
     <div class="row justify-content-center">
         <div class="col-md-8">
             <div class="card">
-                <div class="card-header">{{ __('Скидання пароля') }}</div>
 
                 <div class="card-body">
                     @if (session('status'))

--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -2,11 +2,10 @@
 
 @section('content')
 @include('partials.page-banner', ['title' => __('Скидання пароля')])
-<div class="site-container">
+<div class="site-container form-centered">
     <div class="row justify-content-center">
         <div class="col-md-8">
             <div class="card">
-                <div class="card-header">{{ __('Скидання пароля') }}</div>
 
                 <div class="card-body">
                     <form method="POST" action="{{ route('password.update') }}">

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -2,11 +2,10 @@
 
 @section('content')
 @include('partials.page-banner', ['title' => __('Реєстрація')])
-<div class="site-container">
+<div class="site-container form-centered">
     <div class="row justify-content-center">
         <div class="col-md-8">
             <div class="card">
-                <div class="card-header">{{ __('Реєстрація') }}</div>
 
                 <div class="card-body">
                     <form method="POST" action="{{ route('register') }}" enctype="multipart/form-data">

--- a/resources/views/auth/verify.blade.php
+++ b/resources/views/auth/verify.blade.php
@@ -2,11 +2,10 @@
 
 @section('content')
 @include('partials.page-banner', ['title' => __('Підтвердьте вашу електронну адресу')])
-<div class="site-container">
+<div class="site-container form-centered">
     <div class="row justify-content-center">
         <div class="col-md-8">
             <div class="card">
-                <div class="card-header">{{ __('Підтвердьте вашу електронну адресу') }}</div>
 
                 <div class="card-body">
                     @if (session('resent'))

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -105,7 +105,7 @@
                         <path d="M16 0C7.163 0 0 7.163 0 16s7.163 16 16 16 16-7.163 16-16S24.837 0 16 0zm0 30C8.28 30 2 23.72 2 16S8.28 2 16 2s14 6.28 14 14-6.28 14-14 14z"/>
                         <path d="M11 11h10v10H11z"/>
                     </svg>
-                    <p class="footer-copy">© 2024 FutureTech. All rights reserved.</p>
+                    <p class="footer-copy">© 2024 FutureTech. Усі права захищені.</p>
                 </div>
 
                 <div class="footer-col footer-col--links">


### PR DESCRIPTION
## Summary
- tweak login/register/edit forms and remove duplicate headers
- center auth forms with new `form-centered` helper
- update footer copyright
- adjust global spacing and button styles
- refine login page styles

## Testing
- `composer install -n` *(fails: command not found)*
- `vendor/bin/phpunit` *(not run: composer unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_6842085c94588332b58b7aac539125c8