### PR TITLE
Integrate Quill editor for article forms

### DIFF
--- a/resources/views/auth/articles/create.blade.php
+++ b/resources/views/auth/articles/create.blade.php
@@ -27,7 +27,31 @@
         <div class="form-row">
             <div class="form-field form-field--full">
                 <label for="text" class="form-label">{{ __('Текст') }}</label>
-                <textarea class="form-textarea @error('text') is-invalid @enderror" id="text" name="text" required autocomplete="text" rows="4">{{ old('text') }}</textarea>
+                <input type="hidden" id="text" name="text" value="{{ old('text') }}">
+                <div id="quill-toolbar">
+                    <span class="ql-formats">
+                        <button class="ql-bold" title="Жирний"></button>
+                        <button class="ql-italic" title="Курсив"></button>
+                    </span>
+                    <span class="ql-formats">
+                        <select class="ql-header" title="Заголовок">
+                            <option selected></option>
+                            <option value="1">H1</option>
+                            <option value="2">H2</option>
+                            <option value="3">H3</option>
+                        </select>
+                    </span>
+                    <span class="ql-formats">
+                        <button class="ql-list" value="ordered" title="Нумерований список"></button>
+                        <button class="ql-list" value="bullet" title="Маркірований список"></button>
+                    </span>
+                    <span class="ql-formats">
+                        <button class="ql-link" title="Додати посилання"></button>
+                        <button class="ql-image" title="Вставити зображення"></button>
+                        <button class="ql-code-block" title="Code block"></button>
+                    </span>
+                </div>
+                <div id="quill-editor"></div>
                 @error('text')
                     <span class="invalid-feedback" role="alert">
                         <strong>{{ $message }}</strong>
@@ -43,4 +67,34 @@
         </div>
     </form>
 </div>
+<link href="https://cdn.quilljs.com/1.3.7/quill.snow.css" rel="stylesheet">
+<style>
+    #quill-editor {
+        background: #1A1A1A;
+        color: #EEE;
+        min-height: 300px;
+        padding: 16px;
+        border-radius: 0 0 6px 6px;
+    }
+    #quill-toolbar {
+        border-radius: 6px 6px 0 0;
+    }
+</style>
+<script src="https://cdn.quilljs.com/1.3.7/quill.min.js"></script>
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        var quill = new Quill('#quill-editor', {
+            modules: { toolbar: '#quill-toolbar' },
+            theme: 'snow'
+        });
+        var hiddenInput = document.getElementById('text');
+        quill.root.innerHTML = hiddenInput.value;
+        quill.on('text-change', function () {
+            hiddenInput.value = quill.root.innerHTML;
+        });
+        hiddenInput.form.addEventListener('submit', function () {
+            hiddenInput.value = quill.root.innerHTML;
+        });
+    });
+</script>
 @endsection

--- a/resources/views/auth/articles/edit.blade.php
+++ b/resources/views/auth/articles/edit.blade.php
@@ -23,7 +23,31 @@
         <div class="form-row">
             <div class="form-field form-field--full">
                 <label for="text" class="form-label">{{ __('Текст') }}</label>
-                <textarea class="form-textarea @error('text') is-invalid @enderror" id="text" name="text" required autocomplete="text" rows="4">{{ $article->text }}</textarea>
+                <input type="hidden" id="text" name="text" value="{{ $article->text }}">
+                <div id="quill-toolbar">
+                    <span class="ql-formats">
+                        <button class="ql-bold" title="Жирний"></button>
+                        <button class="ql-italic" title="Курсив"></button>
+                    </span>
+                    <span class="ql-formats">
+                        <select class="ql-header" title="Заголовок">
+                            <option selected></option>
+                            <option value="1">H1</option>
+                            <option value="2">H2</option>
+                            <option value="3">H3</option>
+                        </select>
+                    </span>
+                    <span class="ql-formats">
+                        <button class="ql-list" value="ordered" title="Нумерований список"></button>
+                        <button class="ql-list" value="bullet" title="Маркірований список"></button>
+                    </span>
+                    <span class="ql-formats">
+                        <button class="ql-link" title="Додати посилання"></button>
+                        <button class="ql-image" title="Вставити зображення"></button>
+                        <button class="ql-code-block" title="Code block"></button>
+                    </span>
+                </div>
+                <div id="quill-editor"></div>
                 @error('text')
                     <span class="invalid-feedback" role="alert">
                         <strong>{{ $message }}</strong>
@@ -39,4 +63,34 @@
         </div>
     </form>
 </div>
+<link href="https://cdn.quilljs.com/1.3.7/quill.snow.css" rel="stylesheet">
+<style>
+    #quill-editor {
+        background: #1A1A1A;
+        color: #EEE;
+        min-height: 300px;
+        padding: 16px;
+        border-radius: 0 0 6px 6px;
+    }
+    #quill-toolbar {
+        border-radius: 6px 6px 0 0;
+    }
+</style>
+<script src="https://cdn.quilljs.com/1.3.7/quill.min.js"></script>
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        var quill = new Quill('#quill-editor', {
+            modules: { toolbar: '#quill-toolbar' },
+            theme: 'snow'
+        });
+        var hiddenInput = document.getElementById('text');
+        quill.root.innerHTML = hiddenInput.value;
+        quill.on('text-change', function () {
+            hiddenInput.value = quill.root.innerHTML;
+        });
+        hiddenInput.form.addEventListener('submit', function () {
+            hiddenInput.value = quill.root.innerHTML;
+        });
+    });
+</script>
 @endsection


### PR DESCRIPTION
## Summary
- replace textarea with Quill-based editor on create/edit article pages
- sync Quill content with hidden text input for form submission
- style editor with dark theme and Ukrainian toolbar tooltips

## Testing
- `composer install` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68420de2d9c48332ab888f0726e8abe9