### PR TITLE
Hide unauthorized nav items and widen forms

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -10931,26 +10931,32 @@ footer {
   color: #FFFFFF;
 }
 
-/* Login page adjustments */
+/* Login & form layout adjustments */
 
 .login-page {
   min-height: 100vh;
   display: flex;
   justify-content: center;
   align-items: center;
-  padding-top: 0;
+  padding-top: 80px;
 }
 
 .form-container {
   width: 100%;
-  max-width: 600px;
+  max-width: 768px;
   min-width: 320px;
   padding: 24px;
   background: #1a1a1a;
   border-radius: 8px;
 }
 
-
+.login-page .card-header {
+  margin-bottom: 24px;
+  border: none;
+  background: transparent;
+  text-align: center;
+  font-size: 1.5rem;
+}
 
 .login-page .form-group {
   margin-bottom: 12px;

--- a/public/css/futuretech.css
+++ b/public/css/futuretech.css
@@ -1527,7 +1527,7 @@ section {
 }
 .form-container {
   width: 100%;
-  max-width: 600px;
+  max-width: 768px;
   min-width: 320px;
   padding: 24px;
   background: #1a1a1a;

--- a/resources/sass/blog.scss
+++ b/resources/sass/blog.scss
@@ -41,7 +41,7 @@ footer {
 
 .form-container {
     width: 100%;
-    max-width: 600px;
+    max-width: 768px;
     min-width: 320px;
     padding: 24px;
     background: #1a1a1a;

--- a/resources/views/auth/articles/show.blade.php
+++ b/resources/views/auth/articles/show.blade.php
@@ -16,7 +16,7 @@
         </div>
 
         <h2 class="post-section-title" id="introduction">Вступ</h2>
-        <p class="post-paragraph">{{ $article->text }}</p>
+        <div class="post-paragraph">{!! $article->text !!}</div>
     </div>
     <aside class="post-sidebar">
         <div class="post-meta-card">

--- a/resources/views/components/navbar.blade.php
+++ b/resources/views/components/navbar.blade.php
@@ -9,8 +9,10 @@
     </div>
     <ul class="navbar__center" id="nav-menu">
         <x-nav-item href="/" :active="request()->is('/')">Головна</x-nav-item>
-        <x-nav-item href="/articles" :active="request()->is('articles')">Статті</x-nav-item>
-        <x-nav-item href="/account" :active="request()->is('account')">Аккаунт</x-nav-item>
+        @auth
+            <x-nav-item href="/articles" :active="request()->is('articles')">Статті</x-nav-item>
+            <x-nav-item href="/account" :active="request()->is('account')">Аккаунт</x-nav-item>
+        @endauth
     </ul>
     <div class="navbar__right">
         <x-theme-toggle />


### PR DESCRIPTION
## Summary
- hide article and account links for guest users in navbar
- allow HTML markup in article view
- make form containers wider

## Testing
- `npm run dev`
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842138888d4833281d97b23413159f4